### PR TITLE
OAuth client test independent of app opened by return URI

### DIFF
--- a/src/test/java/uk/bl/odin/orcid/OrcidOAuthClientTest.java
+++ b/src/test/java/uk/bl/odin/orcid/OrcidOAuthClientTest.java
@@ -1,23 +1,30 @@
 package uk.bl.odin.orcid;
 
-import static org.junit.Assert.assertEquals;
-
 import java.io.IOException;
 import java.io.InputStream;
+import java.net.URI;
+import java.net.URISyntaxException;
+import java.nio.charset.Charset;
+import java.util.List;
 import java.util.Properties;
 
 import javax.xml.bind.JAXBException;
 
+import org.apache.http.NameValuePair;
+import org.apache.http.client.utils.URLEncodedUtils;
 import org.junit.Before;
 import org.openqa.selenium.By;
 import org.openqa.selenium.WebDriver;
 import org.openqa.selenium.WebElement;
 import org.openqa.selenium.chrome.ChromeDriver;
-import org.openqa.selenium.support.ui.ExpectedConditions;
+import org.openqa.selenium.support.ui.ExpectedCondition;
 import org.openqa.selenium.support.ui.WebDriverWait;
 
+import uk.bl.odin.orcid.client.OrcidAccessToken;
 import uk.bl.odin.orcid.client.OrcidOAuthClient;
 import uk.bl.odin.orcid.client.constants.OrcidAuthScope;
+
+import static org.junit.Assert.*;
 
 /**
  * Does round trip log in and update profile using supplied constants. requires:
@@ -58,12 +65,17 @@ public class OrcidOAuthClientTest {
 	 */
 	@SuppressWarnings("restriction")
 	// @Test
-	public void testLoginAndUpdate() throws InterruptedException, JAXBException {
-		OrcidOAuthClient client = new OrcidOAuthClient(properties.getProperty("orcidClientID"),
-				properties.getProperty("orcidClientSecret"), properties.getProperty("orcidReturnUri"),
-				Boolean.valueOf(properties.getProperty("orcidSandbox")));
-		String authzreq = client.getAuthzCodeRequest(properties.getProperty("orcidWorkIdentifier"),
-				OrcidAuthScope.CREATE_WORKS);
+	public void testLoginAndUpdate() throws JAXBException, URISyntaxException, IOException {
+		final String clientId = properties.getProperty("orcidClientID");
+		final String clientSecret = properties.getProperty("orcidClientSecret");
+		final String idNumber = properties.getProperty("orcidNumber");
+		final String returnUri = properties.getProperty("orcidReturnUri");
+		final String workIdentifier = properties.getProperty("orcidWorkIdentifier");
+		final Boolean sandbox = Boolean.valueOf(properties.getProperty("orcidSandbox"));
+		final OrcidAuthScope scope = OrcidAuthScope.CREATE_WORKS;
+
+		OrcidOAuthClient client = new OrcidOAuthClient(clientId, clientSecret, returnUri, sandbox);
+		String authzreq = client.getAuthzCodeRequest(workIdentifier, scope);
 
 		System.setProperty("webdriver.chrome.driver", properties.getProperty("chromeDriverLocation"));
 		WebDriver driver = new ChromeDriver();
@@ -78,18 +90,33 @@ public class OrcidOAuthClientTest {
 		p.sendKeys(properties.getProperty("orcidPassword"));
 		driver.findElement(By.id("authorize-button")).click();
 
-		WebElement element = (new WebDriverWait(driver, 10)).until(ExpectedConditions.presenceOfElementLocated(By
-				.id("confirmationForm")));
-		element.submit();
+		(new WebDriverWait(driver, 5)).until(new ExpectedCondition<Boolean>() {
+			public Boolean apply(WebDriver d) {
+				return d.getCurrentUrl().startsWith(returnUri);
+			}
+		});
 
-		WebElement updateElement = (new WebDriverWait(driver, 20)).until(ExpectedConditions.elementToBeClickable(By
-				.id("updateButton")));
-		assertEquals(properties.getProperty("orcidNumber"), driver.findElement(By.id("orcid")).getText());
-		updateElement.click();
+		List<NameValuePair> pairs =
+				URLEncodedUtils.parse(new URI(driver.getCurrentUrl()), Charset.defaultCharset().name());
 
-		WebElement doneElement = (new WebDriverWait(driver, 20)).until(ExpectedConditions.elementToBeClickable(By
-				.id("doneButton")));
-		doneElement.click();
+		driver.close();
+
+		String authorizationCode = null;
+		for (NameValuePair pair : pairs) {
+			if (pair.getName().equals("code")) {
+				authorizationCode = pair.getValue();
+				break;
+			}
+		}
+
+		assertNotNull("No authorization code returned!", authorizationCode);
+
+		OrcidAccessToken accessToken = client.getAccessToken(authorizationCode);
+
+		assertNotNull(accessToken.getAccess_token());
+		assertEquals(accessToken.getOrcid(), idNumber);
+		assertEquals(accessToken.getScope(), scope.toString());
+		assertTrue(accessToken.getExpires_in() > 0);
 	}
 
 }


### PR DESCRIPTION
The current implementation requires the service which is opened by the return URI to contain certain elements like a "doneButton". My patch removes this dependency by parsing the URL for the authorization code and comparing the data in the access token with known values.
